### PR TITLE
Moar Query Fixes

### DIFF
--- a/datastore.go
+++ b/datastore.go
@@ -94,6 +94,22 @@ func (d *Datastore) Query(q query.Query) (query.Results, error) {
 	resBuilder := query.NewResultBuilder(q)
 	if err := d.db.View(func(tx *bbolt.Tx) error {
 		cursor := tx.Bucket(d.bucket).Cursor()
+		if q.Prefix == "" {
+			for k, _ := cursor.First(); k != nil; k, _ = cursor.Next() {
+				result := query.Result{}
+				key := datastore.NewKey(fmt.Sprintf("%v", k))
+				result.Entry.Key = key.String()
+				if !q.KeysOnly {
+					result.Entry.Value, result.Error = d.Get(key)
+				}
+				select {
+				case resBuilder.Output <- result:
+				default:
+					continue
+				}
+			}
+			return nil
+		}
 		pref := []byte(q.Prefix)
 		for k, _ := cursor.Seek(pref); bytes.HasPrefix(k, pref); k, _ = cursor.Next() {
 			result := query.Result{}

--- a/datastore.go
+++ b/datastore.go
@@ -1,7 +1,6 @@
 package dsbbolt
 
 import (
-	"fmt"
 	"os"
 
 	"bytes"
@@ -97,7 +96,7 @@ func (d *Datastore) Query(q query.Query) (query.Results, error) {
 		if q.Prefix == "" {
 			for k, _ := cursor.First(); k != nil; k, _ = cursor.Next() {
 				result := query.Result{}
-				key := datastore.NewKey(fmt.Sprintf("%v", k))
+				key := datastore.NewKey(string(k))
 				result.Entry.Key = key.String()
 				if !q.KeysOnly {
 					result.Entry.Value, result.Error = d.Get(key)
@@ -113,7 +112,7 @@ func (d *Datastore) Query(q query.Query) (query.Results, error) {
 		pref := []byte(q.Prefix)
 		for k, _ := cursor.Seek(pref); bytes.HasPrefix(k, pref); k, _ = cursor.Next() {
 			result := query.Result{}
-			key := datastore.NewKey(fmt.Sprintf("%v", k))
+			key := datastore.NewKey(string(k))
 			result.Entry.Key = key.String()
 			if !q.KeysOnly {
 				result.Entry.Value, result.Error = d.Get(key)

--- a/datastore_test.go
+++ b/datastore_test.go
@@ -62,12 +62,24 @@ func Test_Datastore(t *testing.T) {
 	} else if size != len([]byte("hello world")) {
 		t.Fatal("incorrect data size")
 	}
-
+	// test a query where we specify a search key
 	rs, err := ds.Query(query.Query{Prefix: key.String()})
 	if err != nil {
 		t.Fatal(err)
 	}
 	res, err := rs.Rest()
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, v := range res {
+		fmt.Printf("%+v\n", v)
+	}
+	// test a query where we dont specify a search key
+	rs, err = ds.Query(query.Query{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	res, err = rs.Rest()
 	if err != nil {
 		t.Fatal(err)
 	}


### PR DESCRIPTION
* Closes https://github.com/RTradeLtd/go-ds-bbolt/issues/5 (this error was happening because when bbolt returns the keys it's returned as `[]byte`. The issue with doing `fmt.Sprintf("%v", key)` is that it would just return string representations of the underlying bytes)
* Enables "blank" query searches to iterate through the entire datastore