### PR TITLE
Fix NODE-3 (WIP)

### DIFF
--- a/datastore.go
+++ b/datastore.go
@@ -1,6 +1,7 @@
 package dsbbolt
 
 import (
+	"fmt"
 	"os"
 
 	"bytes"
@@ -103,7 +104,7 @@ func (d *Datastore) Query(q query.Query) (query.Results, error) {
 		pref := []byte(q.Prefix)
 		for k, v := cursor.Seek(pref); k != nil && bytes.HasPrefix(k, pref); k, v = cursor.Next() {
 			var entry query.Entry
-			entry.Key = string(k)
+			entry.Key = fmt.Sprintf("%s%s", q.Prefix, string(k))
 			if !q.KeysOnly {
 				entry.Value = v
 			}

--- a/datastore.go
+++ b/datastore.go
@@ -87,6 +87,7 @@ func (d *Datastore) GetSize(key datastore.Key) (int, error) {
 // https://github.com/ipfs/go-datastore/blob/aa9190c18f1576be98e974359fd08c64ca0b5a94/examples/fs.go#L96
 // https://github.com/etcd-io/bbolt#prefix-scans
 func (d *Datastore) Query(q query.Query) (query.Results, error) {
+	fmt.Printf("%+v\n", q)
 	var entries []query.Entry
 	if err := d.db.View(func(tx *bbolt.Tx) error {
 		cursor := tx.Bucket(d.bucket).Cursor()
@@ -98,6 +99,7 @@ func (d *Datastore) Query(q query.Query) (query.Results, error) {
 					entry.Value = v
 				}
 				entries = append(entries, entry)
+				fmt.Printf("%+v\n", entry)
 			}
 			return nil
 		}
@@ -109,6 +111,7 @@ func (d *Datastore) Query(q query.Query) (query.Results, error) {
 				entry.Value = v
 			}
 			entries = append(entries, entry)
+			fmt.Printf("%+v\n", entry)
 		}
 		return nil
 	}); err != nil {

--- a/datastore.go
+++ b/datastore.go
@@ -73,11 +73,7 @@ func (d *Datastore) Get(key datastore.Key) ([]byte, error) {
 
 // Has returns whether the key is present in our datastore
 func (d *Datastore) Has(key datastore.Key) (bool, error) {
-	data, err := d.Get(key)
-	if err != nil {
-		return false, err
-	}
-	return data != nil, nil
+	return datastore.GetBackedHas(d, key)
 }
 
 // GetSize returns the size of the value referenced by key

--- a/datastore.go
+++ b/datastore.go
@@ -73,7 +73,11 @@ func (d *Datastore) Get(key datastore.Key) ([]byte, error) {
 
 // Has returns whether the key is present in our datastore
 func (d *Datastore) Has(key datastore.Key) (bool, error) {
-	return datastore.GetBackedHas(d, key)
+	data, err := d.Get(key)
+	if err != nil {
+		return false, err
+	}
+	return data != nil, nil
 }
 
 // GetSize returns the size of the value referenced by key

--- a/datastore.go
+++ b/datastore.go
@@ -61,6 +61,9 @@ func (d *Datastore) Get(key datastore.Key) ([]byte, error) {
 	var data []byte
 	if err := d.db.View(func(tx *bbolt.Tx) error {
 		data = tx.Bucket(d.bucket).Get(key.Bytes())
+		if data == nil {
+			return datastore.ErrNotFound
+		}
 		return nil
 	}); err != nil {
 		return nil, err


### PR DESCRIPTION
BoltDB doesn't return error when no data found so that is causing some error. 

For some reason when used in our custom node without blockstore caching, addin to the datastore causes failures due to "errors" being returned when searching the datastore for a non-existing key. 